### PR TITLE
Support important closing comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ a[rel=external]:before{
 
 ```
 
+### Important comments
+This plugin supports important comments (e.g. `/*! critical */`). Any of the
+examples above should work using this comment style.
+
 ## Options
 The plugin accepts an object with additional options.
 

--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ function getAllCriticals(originalCss, criticalCss) {
 		line.parent.raws.semicolon = true;
 		stats.parentRequest++;
 
-		if (line.type === 'comment' && line.text === userOptions.endTag) {
+		if (line.type === 'comment' && (line.text === userOptions.endTag || line.text === '! ' + userOptions.endTag)) {
 			criticalActive = false
 			currentLevel = null;
 			line.remove(); // remove tagging comment

--- a/testsuite/support-important-comments/input.css
+++ b/testsuite/support-important-comments/input.css
@@ -1,3 +1,4 @@
+/*! critical:start */
 strong {
 	font-weight: bold;
 }
@@ -5,6 +6,7 @@ strong {
 p{
 	color: #333;
 }
+/*! critical:end */
 
 @media screen and (min-width: 300px) {
 	strong {

--- a/testsuite/support-important-comments/input.css
+++ b/testsuite/support-important-comments/input.css
@@ -18,7 +18,9 @@ p{
 
 @media screen and (min-width: 500px) {
 	p {
+		/*! critical:start:header */
 		float: left;
+		/*! critical:end */
 		text-decoration: underline;
 	}
 }

--- a/testsuite/support-important-comments/output.css
+++ b/testsuite/support-important-comments/output.css
@@ -1,3 +1,11 @@
+strong {
+	font-weight: bold;
+}
+
+p{
+	color: #333;
+}
+
 @media screen and (min-width: 300px) {
 	strong {
 		color: #f00;

--- a/testsuite/support-important-comments/output.css
+++ b/testsuite/support-important-comments/output.css
@@ -10,7 +10,15 @@ p{
 	strong {
 		color: #f00;
 	}
+}
 
+@media screen and (min-width: 500px) {
+	p {
+		float: left;
+	}
+}
+
+@media screen and (min-width: 300px) {
 	li {
 		display: block;
 		float: left;

--- a/testsuite/support-important-comments/split-settings.json
+++ b/testsuite/support-important-comments/split-settings.json
@@ -1,0 +1,3 @@
+{
+	"modules": ["header"]
+}


### PR DESCRIPTION
This PR adds support for important (`/*! */`) comments for start/end tags as well as modules. Previously, important comments were only supported for block tags (i.e. `/*! critical */`). It also documents important comment support in the `README.md`.

Closes #17.