### PR TITLE
Limit files to be included in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "collectCoverageFrom": [
       "index.js"
     ]
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files. There are a lot of files which don't need to be part of the release package.

<details>
<summary>Before</summary>

```
❯ npm pack
npm notice
npm notice 📦  postcss-critical-split@2.5.3
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 550B   testsuite/deprecation-warn-save-feature/input.css
npm notice 550B   testsuite/dev-debug-mode/input.css
npm notice 550B   testsuite/errors-error-same-start-end-tag/input.css
npm notice 550B   testsuite/errors-prevent-crash-without-split-options/input.css
npm notice 125B   testsuite/markers-block-tags/input.css
npm notice 133B   testsuite/markers-custom-block-tag/input.css
npm notice 119B   testsuite/markers-custom-start-end-tags/input.css
npm notice 127B   testsuite/markers-start-end-tags/input.css
npm notice 503B   testsuite/media-queries-advanced-start-end/input.css
npm notice 458B   testsuite/media-queries-append-001/input.css
npm notice 550B   testsuite/media-queries-append-002/input.css
npm notice 391B   testsuite/media-queries-basic-start-end/input.css
npm notice 172B   testsuite/media-queries-basic/input.css
npm notice 330B   testsuite/media-queries-split/input.css
npm notice 297B   testsuite/modules-basic/input.css
npm notice 649B   testsuite/modules-media-queries/input.css
npm notice 297B   testsuite/modules-no-array/input.css
npm notice 300B   testsuite/modules-separator/input.css
npm notice 507B   testsuite/multiple-font-faces/input.css
npm notice 286B   testsuite/ouput-mode-critical/input.css
npm notice 286B   testsuite/ouput-mode-default/input.css
npm notice 286B   testsuite/ouput-mode-input/input.css
npm notice 286B   testsuite/ouput-mode-rest/input.css
npm notice 550B   testsuite/save-feature/input.css
npm notice 346B   testsuite/special-rules-keyframes-blocktag/input.css
npm notice 367B   testsuite/special-rules-keyframes-start-end-tag/input.css
npm notice 647B   testsuite/support-important-comments/input.css
npm notice 194B   testsuite/weird-first-line-bug/input.css
npm notice 274B   testsuite/deprecation-warn-save-feature/output.css
npm notice 274B   testsuite/dev-debug-mode/output.css
npm notice 274B   testsuite/errors-error-same-start-end-tag/output.css
npm notice 274B   testsuite/errors-prevent-crash-without-split-options/output.css
npm notice 31B    testsuite/markers-block-tags/output.css
npm notice 31B    testsuite/markers-custom-block-tag/output.css
npm notice 55B    testsuite/markers-custom-start-end-tags/output.css
npm notice 55B    testsuite/markers-start-end-tags/output.css
npm notice 220B   testsuite/media-queries-advanced-start-end/output.css
npm notice 197B   testsuite/media-queries-append-001/output.css
npm notice 274B   testsuite/media-queries-append-002/output.css
npm notice 175B   testsuite/media-queries-basic-start-end/output.css
npm notice 94B    testsuite/media-queries-basic/output.css
npm notice 97B    testsuite/media-queries-split/output.css
npm notice 103B   testsuite/modules-basic/output.css
npm notice 334B   testsuite/modules-media-queries/output.css
npm notice 55B    testsuite/modules-no-array/output.css
npm notice 103B   testsuite/modules-separator/output.css
npm notice 308B   testsuite/multiple-font-faces/output.css
npm notice 103B   testsuite/ouput-mode-critical/output.css
npm notice 103B   testsuite/ouput-mode-default/output.css
npm notice 286B   testsuite/ouput-mode-input/output.css
npm notice 127B   testsuite/ouput-mode-rest/output.css
npm notice 274B   testsuite/save-feature/output.css
npm notice 192B   testsuite/special-rules-keyframes-blocktag/output.css
npm notice 188B   testsuite/special-rules-keyframes-start-end-tag/output.css
npm notice 432B   testsuite/support-important-comments/output.css
npm notice 74B    testsuite/weird-first-line-bug/output.css
npm notice 19.2kB critical-split.gif
npm notice 13.8kB index.js
npm notice 463B   testsuite/deprecation-warn-save-feature/process.js
npm notice 316B   testsuite/dev-debug-mode/process.js
npm notice 320B   testsuite/errors-error-same-start-end-tag/process.js
npm notice 428B   testsuite/save-feature/process.js
npm notice 3.7kB  test.js
npm notice 729B   package.json
npm notice 143B   testsuite/deprecation-warn-save-feature/setup.json
npm notice 138B   testsuite/dev-debug-mode/setup.json
npm notice 153B   testsuite/errors-error-same-start-end-tag/setup.json
npm notice 127B   testsuite/errors-prevent-crash-without-split-options/setup.json
npm notice 98B    testsuite/markers-block-tags/setup.json
npm notice 100B   testsuite/markers-custom-block-tag/setup.json
npm notice 104B   testsuite/markers-custom-start-end-tags/setup.json
npm notice 103B   testsuite/markers-start-end-tags/setup.json
npm notice 154B   testsuite/media-queries-advanced-start-end/setup.json
npm notice 148B   testsuite/media-queries-append-001/setup.json
npm notice 144B   testsuite/media-queries-append-002/setup.json
npm notice 138B   testsuite/media-queries-basic-start-end/setup.json
npm notice 106B   testsuite/media-queries-basic/setup.json
npm notice 126B   testsuite/media-queries-split/setup.json
npm notice 118B   testsuite/modules-basic/setup.json
npm notice 122B   testsuite/modules-media-queries/setup.json
npm notice 151B   testsuite/modules-no-array/setup.json
npm notice 109B   testsuite/modules-separator/setup.json
npm notice 121B   testsuite/multiple-font-faces/setup.json
npm notice 119B   testsuite/ouput-mode-critical/setup.json
npm notice 106B   testsuite/ouput-mode-default/setup.json
npm notice 118B   testsuite/ouput-mode-input/setup.json
npm notice 111B   testsuite/ouput-mode-rest/setup.json
npm notice 147B   testsuite/save-feature/setup.json
npm notice 153B   testsuite/special-rules-keyframes-blocktag/setup.json
npm notice 158B   testsuite/special-rules-keyframes-start-end-tag/setup.json
npm notice 113B   testsuite/support-important-comments/setup.json
npm notice 109B   testsuite/weird-first-line-bug/setup.json
npm notice 18B    testsuite/deprecation-warn-save-feature/split-settings.json
npm notice 19B    testsuite/dev-debug-mode/split-settings.json
npm notice 53B    testsuite/errors-error-same-start-end-tag/split-settings.json
npm notice 3B     testsuite/markers-block-tags/split-settings.json
npm notice 36B    testsuite/markers-custom-block-tag/split-settings.json
npm notice 53B    testsuite/markers-custom-start-end-tags/split-settings.json
npm notice 3B     testsuite/markers-start-end-tags/split-settings.json
npm notice 3B     testsuite/media-queries-advanced-start-end/split-settings.json
npm notice 3B     testsuite/media-queries-append-001/split-settings.json
npm notice 3B     testsuite/media-queries-append-002/split-settings.json
npm notice 3B     testsuite/media-queries-basic-start-end/split-settings.json
npm notice 3B     testsuite/media-queries-basic/split-settings.json
npm notice 3B     testsuite/media-queries-split/split-settings.json
npm notice 42B    testsuite/modules-basic/split-settings.json
npm notice 42B    testsuite/modules-media-queries/split-settings.json
npm notice 25B    testsuite/modules-no-array/split-settings.json
npm notice 61B    testsuite/modules-separator/split-settings.json
npm notice 3B     testsuite/multiple-font-faces/split-settings.json
npm notice 26B    testsuite/ouput-mode-critical/split-settings.json
npm notice 3B     testsuite/ouput-mode-default/split-settings.json
npm notice 23B    testsuite/ouput-mode-input/split-settings.json
npm notice 22B    testsuite/ouput-mode-rest/split-settings.json
npm notice 18B    testsuite/save-feature/split-settings.json
npm notice 3B     testsuite/special-rules-keyframes-blocktag/split-settings.json
npm notice 3B     testsuite/special-rules-keyframes-start-end-tag/split-settings.json
npm notice 27B    testsuite/support-important-comments/split-settings.json
npm notice 22B    testsuite/weird-first-line-bug/split-settings.json
npm notice 9.4kB  README.md
npm notice === Tarball Details ===
npm notice name:          postcss-critical-split
npm notice version:       2.5.3
npm notice filename:      postcss-critical-split-2.5.3.tgz
npm notice package size:  34.6 kB
npm notice unpacked size: 68.9 kB
npm notice shasum:        25bcb6293a874873041e03f38fe3b7e9498a4d32
npm notice integrity:     sha512-DVpGnNDv/Sveb[...]/ZI7eBG4GNdaA==
npm notice total files:   121
npm notice
postcss-critical-split-2.5.3.tgz
```

</details>

<details>
<summary>After</summary>

```
❯ npm pack
npm notice
npm notice 📦  postcss-critical-split@2.5.3
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 13.8kB index.js
npm notice 762B   package.json
npm notice 9.4kB  README.md
npm notice === Tarball Details ===
npm notice name:          postcss-critical-split
npm notice version:       2.5.3
npm notice filename:      postcss-critical-split-2.5.3.tgz
npm notice package size:  7.4 kB
npm notice unpacked size: 25.1 kB
npm notice shasum:        d89cfd069626219ff0aff4fee14cffa87ad5b537
npm notice integrity:     sha512-oyzV1IoTijms9[...]UXVFZWuVg3tIw==
npm notice total files:   4
npm notice
postcss-critical-split-2.5.3.tgz
```

</details>